### PR TITLE
feat: 레이블 수정

### DIFF
--- a/RandomColorGenerator.xcodeproj/project.pbxproj
+++ b/RandomColorGenerator.xcodeproj/project.pbxproj
@@ -6,6 +6,10 @@
 	objectVersion = 77;
 	objects = {
 
+/* Begin PBXBuildFile section */
+		BF310A082D5356F200A6B786 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = BF310A072D5356EE00A6B786 /* README.md */; };
+/* End PBXBuildFile section */
+
 /* Begin PBXContainerItemProxy section */
 		BF3109E92D5341CC00A6B786 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -27,6 +31,7 @@
 		BF3109D22D5341CB00A6B786 /* RandomColorGenerator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RandomColorGenerator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BF3109E82D5341CC00A6B786 /* RandomColorGeneratorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RandomColorGeneratorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BF3109F22D5341CD00A6B786 /* RandomColorGeneratorUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RandomColorGeneratorUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		BF310A072D5356EE00A6B786 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -56,6 +61,11 @@
 		BF3109F52D5341CD00A6B786 /* RandomColorGeneratorUITests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = RandomColorGeneratorUITests;
+			sourceTree = "<group>";
+		};
+		BF310A092D5357A600A6B786 /* image */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = image;
 			sourceTree = "<group>";
 		};
 /* End PBXFileSystemSynchronizedRootGroup section */
@@ -88,6 +98,8 @@
 		BF3109C92D5341CB00A6B786 = {
 			isa = PBXGroup;
 			children = (
+				BF310A092D5357A600A6B786 /* image */,
+				BF310A072D5356EE00A6B786 /* README.md */,
 				BF3109D42D5341CB00A6B786 /* RandomColorGenerator */,
 				BF3109EB2D5341CC00A6B786 /* RandomColorGeneratorTests */,
 				BF3109F52D5341CD00A6B786 /* RandomColorGeneratorUITests */,
@@ -122,6 +134,7 @@
 			);
 			fileSystemSynchronizedGroups = (
 				BF3109D42D5341CB00A6B786 /* RandomColorGenerator */,
+				BF310A092D5357A600A6B786 /* image */,
 			);
 			name = RandomColorGenerator;
 			packageProductDependencies = (
@@ -225,6 +238,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BF310A082D5356F200A6B786 /* README.md in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/RandomColorGenerator/Base.lproj/Main.storyboard
+++ b/RandomColorGenerator/Base.lproj/Main.storyboard
@@ -28,48 +28,6 @@
                                     <action selector="changeColorTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="kHk-j0-dYt"/>
                                 </connections>
                             </button>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Red" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7kA-CQ-Ffk">
-                                <rect key="frame" x="66" y="369" width="60" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" systemColor="systemRedColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Green" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="csG-jd-bWD">
-                                <rect key="frame" x="166" y="369" width="60" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" systemColor="systemGreenColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Blue" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="X7f-RR-SBO">
-                                <rect key="frame" x="266" y="369" width="60" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" systemColor="systemBlueColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="255" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="er9-gA-bGi">
-                                <rect key="frame" x="66" y="407" width="60" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="255" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yad-R7-Dbj">
-                                <rect key="frame" x="166" y="407" width="60" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="255" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="T5U-C6-ctv">
-                                <rect key="frame" x="266" y="407" width="60" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZJL-51-CEF">
                                 <rect key="frame" x="258" y="490" width="68" height="35"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
@@ -82,15 +40,20 @@
                                     <action selector="resetTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="k0E-Gd-46O"/>
                                 </connections>
                             </button>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="R: 255, G: 255, B: 255" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RYh-ct-ftz">
+                                <rect key="frame" x="96" y="401" width="200" height="50"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="JZy-ir-558"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
                     <connections>
                         <outlet property="backgroundColorView" destination="ybk-sP-NyA" id="BaD-U5-0Sv"/>
-                        <outlet property="blueValueLabel" destination="T5U-C6-ctv" id="oA6-zZ-hN5"/>
-                        <outlet property="greenValueLabel" destination="yad-R7-Dbj" id="Qa6-6h-v4z"/>
-                        <outlet property="redValueLabel" destination="er9-gA-bGi" id="lPL-MI-bQv"/>
+                        <outlet property="rgbValueLabel" destination="RYh-ct-ftz" id="5QR-JU-Qpt"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
@@ -101,15 +64,6 @@
     <resources>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
-        <systemColor name="systemBlueColor">
-            <color red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </systemColor>
-        <systemColor name="systemGreenColor">
-            <color red="0.20392156862745098" green="0.7803921568627451" blue="0.34901960784313724" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </systemColor>
-        <systemColor name="systemRedColor">
-            <color red="1" green="0.23137254901960785" blue="0.18823529411764706" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/RandomColorGenerator/ViewController.swift
+++ b/RandomColorGenerator/ViewController.swift
@@ -10,9 +10,7 @@ import UIKit
 class ViewController: UIViewController {
 
     @IBOutlet weak var backgroundColorView: UIView!
-    @IBOutlet weak var redValueLabel: UILabel!
-    @IBOutlet weak var greenValueLabel: UILabel!
-    @IBOutlet weak var blueValueLabel: UILabel!
+    @IBOutlet weak var rgbValueLabel: UILabel!
     
     @IBAction func changeColorTapped(_ sender: UIButton) {
         backgroundColorView.backgroundColor = generateRandomColor()
@@ -35,9 +33,20 @@ class ViewController: UIViewController {
     }
     
     func changeRGBLabel(red: CGFloat, green: CGFloat, blue: CGFloat) {
-        redValueLabel.text = String(Int(red * 255))
-        greenValueLabel.text = String(Int(green * 255))
-        blueValueLabel.text = String(Int(blue * 255))
+        rgbValueLabel.text = "R: \(Int(red * 255)), G: \(Int(green * 255)), B: \(Int(blue * 255))"
+        rgbValueLabel.textColor = (relativeLuminance(red: red, green: green, blue: blue) < 0.5) ? .white : .black
+    }
+    
+    func gammaCorrection(value: CGFloat) -> CGFloat {
+        return (value <= 0.03928) ? (value / 12.92) : pow((value + 0.055) / 1.055, 2.4)
+    }
+    
+    func relativeLuminance(red: CGFloat, green: CGFloat, blue: CGFloat) -> CGFloat {
+        let r = gammaCorrection(value: red)
+        let g = gammaCorrection(value: green)
+        let b = gammaCorrection(value: blue)
+        
+        return 0.2126 * r + 0.7152 * g + 0.0722 * b
     }
     
     override func viewDidLoad() {


### PR DESCRIPTION
- 기존 6개의 레이블을 하나로 변경
- 랜덤 배경색의 명도에 따라 레이블의 글자색이 흰색 또는 검정색으로 변경되는 기능 추가